### PR TITLE
Using fgets input to avoid buffer overflow

### DIFF
--- a/main.c
+++ b/main.c
@@ -4,7 +4,8 @@
 int main(void) {
     char buf[256];
     printf("shell cmd: ");
-    gets(buf);
+    fgets(buf, 255, stdin);
+    char[255] = '\0';
     system(buf);
     return 0;
 }


### PR DESCRIPTION
The fgets function permits us to avoid buffer overflow, which is recommended when using the system function.